### PR TITLE
Updated DMR Net details and removed invalid link

### DIFF
--- a/_pages/dmr.md
+++ b/_pages/dmr.md
@@ -60,8 +60,6 @@ but then you own it and this one will remain should you ever need it again.
 
 Enjoy your radio.
 
-Les Neilson VK4LEZ, BARC President.
-
 ## VKDMR Hotspot Setup
 
 Michael Lanagan (VK4MWL) has pulled together a great guide to DMR hotspots and
@@ -74,7 +72,6 @@ how to set yours up.
 
 * Repeaters [http://rpt.vkdmr.com/](http://rpt.vkdmr.com/){:target="_blank"}
 * Hot Spots [http://hot.vkdmr.com/](http://hot.vkdmr.com/){:target="_blank"}
-* [VK4DRM Repeater Map](https://www.google.com/maps/d/viewer?mid=1pN0ls-uQ6GIixGanunLe0HETqo8&ll=-27.331080754756925%2C153.09384449189344&z=9){:target="_blank"}
 * VK DMR [https://vkdmr.com/](https://vkdmr.com/){:target="_blank"}
 
 ## DMR Articles

--- a/_pages/nets.md
+++ b/_pages/nets.md
@@ -12,13 +12,13 @@ All licensed amateurs are welcome to join us.
 
 # DMR Monday evening Net
 
-A Digital net is run on VK-DMR each Monday night at 7:00PM onwards to 8pm.
+A Digital net is run on Free DMR each Monday night at 7:00PM onwards to 8pm.
 
-Using your Hopspot or your local repeater the talk group is TG "5"
+Using your Hopspot or your local repeater the talk group is TG "5050"
 
 Our New Motorola repeater is now fully installed and operating
 
-set your radio to listen to 438.725 and transmit on 431.725 to work the repeater correctly
+Set your radio to listen to 438.725 and transmit on 431.725 to work the repeater correctly
 
 # HF Monday evening Net
 


### PR DESCRIPTION
Removed reference to the president in the DMR article.
Updated Monday net to FreeDMR and TG5050.
Remove VMDMR repeater link (no longer valid).