### PR TITLE
Restrict Recent Updates list

### DIFF
--- a/_includes/calendar.html
+++ b/_includes/calendar.html
@@ -13,11 +13,17 @@
     We also track the number rendered so we can show a "no events"
     message if we ignored all the events.
 
-    There is an optional parameter for the include to limit the max
-    number of entries to show.
+    There are optional parameter to the template:
 
-    include.limit - default 1000 (essentially all)
+      include.limit - default 1000 (essentially all) - max items to show
+
+    Notes: The plus: 0 filters convert strings to numbers
 {% endcomment %}
+
+{% assign today = "now" | date: "%Y-%m-%d" | date: "%s" | plus: 0 %}
+{% assign month = "_" %}
+{% assign item_count = include.limit | default: 1000 | plus: 0 %}
+{% assign events = site.data.calendar.events | sort: "date" %}
 
 <table>
     <thead>
@@ -27,16 +33,10 @@
         </tr>
     </thead>
     <tbody>
-{% assign today = "now" | date: "%Y-%m-%d" | date: "%s" %}
-{% assign month = "_" %}
-{% assign event_count = 0 %}
-{% assign max_count = include.limit | default: 1000 | plus: 0 %}
-{% assign events = site.data.calendar.events | sort: "date" %}
 {% for e in events %}
-    {% assign event_date = e.date | date: "%s" %}
+    {% assign event_date = e.date | date: "%s" | plus: 0 %}
     {% assign event_month = e.date | date: "%B" %}
-    {% if event_date >= today and event_count < max_count  %}
-        {% assign event_count = event_count | plus: 1 %}
+    {% if event_date >= today %}
         {% if month != event_month %}
             {% assign month = event_month %}
             <tr><th colspan="2" class="notice--info"><h4>{{ month }}</h4></th></tr>
@@ -51,6 +51,10 @@
                 {{ e.description | markdownify }}
             </td>
         </tr>
+        {% assign item_count = item_count | minus: 1 %}
+        {% if item_count <= 0 %}
+            {% break %}
+        {% endif %}
     {% endif %}
 {% endfor %}
 

--- a/_includes/recent.html
+++ b/_includes/recent.html
@@ -1,18 +1,49 @@
+{% comment %}
+    We wish to remove news that is older than ~6 months.
+    This is a bit tricky as we have to use dates as seconds since epoc
+    (which is explained more in calendar.html).
+
+    Assume we are dealing with 26 weeks rather than months which makes the calcualtion
+    a lot easier.
+
+    There are optional parameters to the template:
+
+      include.limit - default 10 - max items to show
+      include.weeksold - default 26 - max age of items to show
+
+
+    Notes: The plus: 0 filters convert strings to numbers
+{% endcomment %}
+
+{% assign max_weeks = include.weeksold | default: 26 | plus: 0 %}
+{% assign today = "now" | date: "%Y-%m-%d" | date: "%s" %}
+{% assign max_age_seconds = max_weeks | times: 7 | times: 24 | times: 60 | times: 60 %}
+{% assign earilest_date = today | minus: max_age_seconds %}
+
 {% assign latest_items = site.posts | concat: site.articles | concat: site.projects %}
 {% assign latest_items = latest_items | sort: "date" | reverse %}
+
+{% assign item_count = include.limit | default: 10 | plus: 0 %}
 
 <table>
     <thead>
         <tr><th>Recent Updates</th></tr>
     </thead>
     <tbody>
-{% for p in latest_items limit:5 %}
+{% for p in latest_items %}
+    {% assign item_date = p.date | date: "%s" | plus: 0 %}
+    {% if item_date >= earilest_date %}
         <tr>
             <td>
                 <a href="{{p.url}}"><strong>{{p.title}}</strong></a><br/>
                 {{p.excerpt}}
             </td>
         </tr>
+        {% assign item_count = item_count | minus: 1 %}
+        {% if item_count <= 0 %}
+            {% break %}
+        {% endif %}
+    {% endif %}
 {% endfor %}
     </tbody>
 </table>

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ related: false
 
 Welcome to the Brisbane Amateur Radio Club website!
 
-{% include recent.html %}
+{% include recent.html weeksold="26" limit="5" %}
 
 ### Club Calendar
 


### PR DESCRIPTION
The recent updates are now restricted to items in the last 26 weeks (6 months). This is configurable when included in the `index.md` as a parameter.